### PR TITLE
Render app in div w/ id 'cswrapper'; Add 'embed' (module) build target

### DIFF
--- a/ui/app.js
+++ b/ui/app.js
@@ -108,5 +108,5 @@ function App(props) {
 }
 
 document.addEventListener("DOMContentLoaded", function () {
-  render(<App />, document.body);
+  render(<App />, document.getElementById("cswrapper"));
 });

--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,8 @@
   <script type="module" src="app.js"></script>
 </head>
 
-<body></body>
+<body>
+  <div id="cswrapper"></div>
+</body>
 
 </html>

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,14 @@
     "build": "parcel build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "targets": {
+    "site": {
+      "source": "index.html"
+    },
+    "embed": {
+      "source": "app.js"
+    }
+  },
   "includeNodeModules": true,
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
* Specify 2 separate ui build targets, `embed` and `site`.
* Render app in div with id 'cswrapper' instead of directly in the <body> tag.